### PR TITLE
removing asis from glimpse output

### DIFF
--- a/01_intro_to_r/intro_to_r.Rmd
+++ b/01_intro_to_r/intro_to_r.Rmd
@@ -163,7 +163,7 @@ Because this command is used to explore the data, it is not necessary for your s
 
 This command should output the following
 
-```{r glimpse-data-result, echo=FALSE, results="asis"}
+```{r glimpse-data-result, echo=FALSE}
 glimpse(arbuthnot)
 ```
 


### PR DESCRIPTION
I think this was my fault! I added a new code chunk, but forgot to omit `results = "asis"` from the chunk options. 